### PR TITLE
Update evalai host url to submissions.rangl.org

### DIFF
--- a/random_agent_submission/README.md
+++ b/random_agent_submission/README.md
@@ -69,7 +69,7 @@ The image can be submitted as follows:
 2. Set the EvalAI host
 
    ```
-   evalai host -sh http://<RANGL_IP_ADDRESS>:8000
+   evalai host -sh http:submissions.rangl.org
    ```
 
 3. Login
@@ -83,7 +83,6 @@ The image can be submitted as follows:
    ```shell
    evalai push submission:v0.1.0 --phase nztc-dev-5
    ```
-
 
 
 


### PR DESCRIPTION
We're now using DNS to make submissions easier:

```shell
# old method
evalai host -sh http://<RANGL_IP_ADDRESS>:8000

# new method
evalai host -sh http://submissions.rangl.org
```


Implements #41 