### PR TITLE
Change the character � to £.

### DIFF
--- a/environment/reference_environment_direct_deployment/env.py
+++ b/environment/reference_environment_direct_deployment/env.py
@@ -519,11 +519,11 @@ def plot_episode(state, fname):
     #     np.array(state.observations_all)[:, :5]
     # )  # first 5 elements of observations are step counts and first 4 randomized costs
     plt.plot(np.array(state.observations_all)[:,0], label="step counts", color='black')
-    plt.plot(np.array(state.observations_all)[:,1], label="CCS Capex £/tonne")
-    plt.plot(np.array(state.observations_all)[:,2], label="CCS Opex £/tonne")
-    plt.plot(np.array(state.observations_all)[:,3], label="Carbon price £/tonne")
-    plt.plot(np.array(state.observations_all)[:,4], label="Offshore wind Devex £/kW")
-    # plt.plot(np.array(state.observations_all)[:,5], label="Offshore wind Capex £/kW")
+    plt.plot(np.array(state.observations_all)[:,1], label="CCS Capex Â£/tonne")
+    plt.plot(np.array(state.observations_all)[:,2], label="CCS Opex Â£/tonne")
+    plt.plot(np.array(state.observations_all)[:,3], label="Carbon price Â£/tonne")
+    plt.plot(np.array(state.observations_all)[:,4], label="Offshore wind Devex Â£/kW")
+    # plt.plot(np.array(state.observations_all)[:,5], label="Offshore wind Capex Â£/kW")
     plt.xlabel("time")
     plt.ylabel("observations")
     plt.legend(loc='lower right',fontsize='xx-small')


### PR DESCRIPTION
When merging `calibrate_env_and_linprog` to `main` in https://github.com/rangl-labs/netzerotc/commit/216846181382f0972fc3eb7ffd28f7f113824de7, the conflicts in `env.py` were resolved locally in WinMerge, which somehow converted the pound sign £ to another character �, which is shown as the correct pound sign in GitHub webpage and Spyder IDE, but it will prevent the env creation using `env = gym.make("reference_environment_direct_deployment:rangl-nztc-v0")`. Only in GitHub's web IDE (https://github.dev) or a git GUI's diff tool, the problematic character will be revealed as �. Now it's reverted back to the proper pound sign £.