### PR TITLE
Updated scripts to test other OpenAI RL algorithms

### DIFF
--- a/local_agent_training_and_evaluation/evaluate.py
+++ b/local_agent_training_and_evaluation/evaluate.py
@@ -3,15 +3,17 @@
 import os
 import numpy as np
 import gym
-from stable_baselines3 import PPO
+from stable_baselines3 import PPO, A2C, DDPG
 
 from util import Evaluate
 
 env = gym.make("reference_environment_direct_deployment:rangl-nztc-v0")
 
-trained_models_dir = "noise_sigma0.1_reward_plus_step_count_jobs_increment_modified_workbook_noNoiseObs"
+trained_models_dir = "noise_sigma0.1_modified_workbook_finalized_env.py_DDPG"
 model_number_str = "39"
-agent = PPO.load("./" + trained_models_dir + "/" + "MODEL_" + model_number_str)
+# agent = PPO.load("./" + trained_models_dir + "/" + "MODEL_" + model_number_str)
+# agent = A2C.load("./" + trained_models_dir + "/" + "MODEL_" + model_number_str)
+agent = DDPG.load("./" + trained_models_dir + "/" + "MODEL_" + model_number_str)
 evaluate = Evaluate(env, agent)
 seeds = evaluate.read_seeds(fname="seeds.csv")
 # fmt: off

--- a/local_agent_training_and_evaluation/plot_learning_curve.py
+++ b/local_agent_training_and_evaluation/plot_learning_curve.py
@@ -4,30 +4,35 @@ import os
 import numpy as np
 import gym
 import matplotlib.pyplot as plt
-from stable_baselines3 import PPO
+from stable_baselines3 import PPO, A2C, DDPG
 
 from util import Evaluate
-import reference_environment_direct_deployment
+# import reference_environment_direct_deployment
 
 env = gym.make("reference_environment_direct_deployment:rangl-nztc-v0")
+
+os.chdir("./noise_sigma0.1_modified_workbook_finalized_env.py_DDPG/")
 
 ### Evaluate RL agents model_0 to model_39
 trained_models = 40
 episodes_per_model = 1000
 mean_rewards = []
 for i in range(trained_models):
-    agent = PPO.load("MODEL_"+str(i))
+    # agent = PPO.load("MODEL_"+str(i))
+    # agent = A2C.load("MODEL_"+str(i))
+    agent = DDPG.load("MODEL_"+str(i))
     evaluate = Evaluate(env, agent)
-    seeds = evaluate.read_seeds(fname="seeds.csv")
+    seeds = evaluate.read_seeds(fname="../seeds.csv")
     mean_reward = evaluate.RL_agent(seeds) # Add your agent to the Evaluate class and call it here e.g. evaluate.my_agent(seeds)
     mean_rewards.append(mean_reward)
+    print(i)
 print("Mean rewards for RL agents:", mean_rewards)
 
 ### Plot learning curve
 plt.plot(mean_rewards)
-plt.xlabel("training time ("+str(trained_models)+" models with "+str(episodes_per_model)+" episodes each")
+plt.xlabel("training time ("+str(trained_models)+" models with "+str(episodes_per_model)+" episodes each)")
 plt.ylabel("reward")
 plt.title("learning curve")
-plt.savefig("learning curve.png")
-
+plt.savefig("learning curve eval on noisy.png")
+os.chdir("../")
 

--- a/local_agent_training_and_evaluation/train.py
+++ b/local_agent_training_and_evaluation/train.py
@@ -9,11 +9,11 @@ env = gym.make("reference_environment_direct_deployment:rangl-nztc-v0")
 
 # Train an RL agent on the environment
 trainer = Trainer(env)
-os.chdir("./saved_models/")
-# os.chdir("./noise_sigma0.1_reward_plus_step_count_jobs_increment_modified_workbook_noNoiseObs/")
+# os.chdir("./saved_models/")
+os.chdir("./noise_sigma0.1_modified_workbook_finalized_env.py_DDPG/")
 # To resume a previously trained model:
 # trainer.train_rl(models_to_train=80, episodes_per_model=1000, last_model_number=39)
 # To train from scratch:
-trainer.train_rl(models_to_train=1, episodes_per_model=100)
+trainer.train_rl(models_to_train=40, episodes_per_model=1000)
 os.chdir("../")
 

--- a/local_agent_training_and_evaluation/util.py
+++ b/local_agent_training_and_evaluation/util.py
@@ -5,8 +5,10 @@ import csv
 import pandas as pd
 import numpy as np
 import gym
-from stable_baselines3 import PPO
-from stable_baselines3.ppo import MlpPolicy
+from stable_baselines3 import PPO, A2C, DDPG
+# from stable_baselines3.ppo import MlpPolicy
+# from stable_baselines3.a2c import MlpPolicy
+# from stable_baselines3.ddpg import MlpPolicy
 # from pathlib import Path
 
 
@@ -17,7 +19,9 @@ class Trainer:
 
     def train_rl(self, models_to_train=40, episodes_per_model=100, last_model_number=-1):
         # specify the RL algorithm to train (eg ACKTR, TRPO...)
-        model = PPO(MlpPolicy, self.env, verbose=1)
+        # model = PPO(MlpPolicy, self.env, verbose=1)
+        # model = A2C("MlpPolicy", self.env, verbose=1)
+        model = DDPG("MlpPolicy", self.env, verbose=1)
         if last_model_number > -1:
             # last_model_number = 39
             model.load("MODEL_" + str(last_model_number))


### PR DESCRIPTION
Updated `evaluate.py`, `plot_learning_curve.py`, `train.py`, and `util.py` to test other RL algorithms on the Virtual Machine as in https://github.com/rangl-labs/netzerotc/issues/86, and pushed the changes directly from the VM.